### PR TITLE
fix memory leaking

### DIFF
--- a/src/renderwindow.cpp
+++ b/src/renderwindow.cpp
@@ -95,6 +95,7 @@ void RenderWindow::render(float p_x, float p_y, const char* p_text, TTF_Font* fo
 
 		SDL_RenderCopy(renderer, message, &src, &dst);
 		SDL_FreeSurface(surfaceMessage);
+	 	SDL_DestroyTexture(message);
 }
 
 void RenderWindow::renderCenter(float p_x, float p_y, const char* p_text, TTF_Font* font, SDL_Color textColor)
@@ -116,6 +117,7 @@ void RenderWindow::renderCenter(float p_x, float p_y, const char* p_text, TTF_Fo
 
 		SDL_RenderCopy(renderer, message, &src, &dst);
 		SDL_FreeSurface(surfaceMessage);
+		SDL_DestroyTexture(message);
 }
 
 void RenderWindow::display()


### PR DESCRIPTION
fix memory leaking by destroying the textures after drawing text