### PR TITLE
Make building much easier and flexible

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,21 +1,25 @@
-name: build
+name: CI
 
-on: [push, pull_request]
+on:
+  # Trigger on all pushes and PRs
+  push:
+  pull_request:
+
+  # Allow manually running workflow
+  workflow_dispatch:
 
 jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: setup
-        run: sudo apt-get install -y mingw-w64 libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev
-      - name: build
+      - name: Setup dependencies
         run: |
-          g++ -c src/*.cpp -std=c++14 -O3 -Wall -m64 -I include && mkdir -p bin/release && g++ *.o -o bin/release/main -s -lSDL2main -lSDL2 -lSDL2_image -lSDL2_ttf -lSDL2_mixer
-      - name: copy resources
+          sudo apt-get install -y mingw-w64 libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev
+      - name: Build
         run: |
-          cp -vr ./res/ ./bin/release/
-      - name: Upload linux Binary
+          make linux
+      - name: Upload Linux build
         uses: actions/upload-artifact@v2
         with:
           name: linux
@@ -25,18 +29,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: setup
-        run: sudo apt-get install -y git python3 cmake
-      - name: setup emscripten
+      - name: Setup dependencies
         run: |
-          git clone https://github.com/emscripten-core/emsdk.git && cd emsdk && git pull && ./emsdk install latest && ./emsdk activate latest && source ./emsdk_env.sh && cd ..
-      - name: build
+          sudo apt-get install -y git python3 cmake
+      - name: Setup emscripten
         run: |
-          source ./emsdk/emsdk_env.sh && emcc src/main.cpp src/entity.cpp src/renderwindow.cpp src/ball.cpp src/tile.cpp src/hole.cpp -I include -O2 -s USE_SDL=2 -s USE_SDL_IMAGE=2 -s 'SDL2_IMAGE_FORMATS=["png"]' -s USE_SDL_TTF=2 -s USE_SDL_MIXER=2 --preload-file res -o index.html
-      - name: copy files to folder
+          git clone https://https://github.com/emscripten-core/emsdk.git
+          cd emsdk
+          git pull
+          ./emsdk install latest
+          ./emsdk activate latest
+          source ./emsdk_env.sh
+          cd ..
+      - name: Build
         run: |
-          mkdir emscripten && cp ./index.data ./emscripten && cp ./index.html ./emscripten  && cp ./index.js ./emscripten  && cp ./index.wasm ./emscripten
-      - name: Upload linux Binary
+          source ./emsdk/emsdk_env.sh
+          make web
+      - name: Copy files to folder
+        run: |
+          mkdir emscripten
+          cp ./index.data ./emsripten
+          cp ./index.html ./emsripten
+          cp ./index.js ./emsripten
+          cp ./index.wasm ./emsripten
+      - name: Upload Web build
         uses: actions/upload-artifact@v2
         with:
           name: emscripten

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,11 +9,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-linux:
+  linux-build:
+    name: Linux build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup dependencies
+      - name: Install APT dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -21,25 +21,35 @@ jobs:
             libsdl2-dev \
             libsdl2-image-dev \
             libsdl2-ttf-dev \
-            libsdl2-mixer-dev
+            libsdl2-mixer-dev \
+      - name: Checkout repository
+        uses: actions/checkout@v2
       - name: Build
-        run: |
-          make
+        run: make
       - name: Upload Linux build
         uses: actions/upload-artifact@v2
         with:
           name: linux-build
           path: ./bin/releases/linux
 
-  build-web:
+  web-build:
+    name: Web build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup dependencies
+      - name: Install APT dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y git python3 cmake
-      - name: Setup emscripten
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup emscripten (cache)
+        uses: actions/cache@v2
+        id: emsdk-cache
+        with:
+          path: ./emsdk
+          key: emscripten-cache
+      - name: Setup emscripten (install)
+        if: steps.emsdk-cache.outputs.cache-hit != 'true'
         run: |
           git clone https://github.com/emscripten-core/emsdk.git
           cd emsdk
@@ -51,7 +61,7 @@ jobs:
         run: |
           source ./emsdk/emsdk_env.sh
           make web
-      - name: Upload web build
+      - name: Upload Web build
         uses: actions/upload-artifact@v2
         with:
           name: web-build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,15 +15,21 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup dependencies
         run: |
-          sudo apt-get install -y mingw-w64 libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev
+          sudo apt-get update
+          sudo apt-get install -y \
+            mingw-w64 \
+            libsdl2-dev \
+            libsdl2-image-dev \
+            libsdl2-ttf-dev \
+            libsdl2-mixer-dev
       - name: Build
         run: |
-          make linux
+          make
       - name: Upload Linux build
         uses: actions/upload-artifact@v2
         with:
-          name: linux
-          path: ./bin/release
+          name: linux-build
+          path: ./bin/releases/linux
 
   build-web:
     runs-on: ubuntu-latest
@@ -31,6 +37,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y git python3 cmake
       - name: Setup emscripten
         run: |
@@ -39,14 +46,13 @@ jobs:
           git pull
           ./emsdk install latest
           ./emsdk activate latest
-          source ./emsdk_env.sh
           cd ..
       - name: Build
         run: |
           source ./emsdk/emsdk_env.sh
           make web
-      - name: Upload Web build
+      - name: Upload web build
         uses: actions/upload-artifact@v2
         with:
-          name: emscripten
-          path: ./emscripten
+          name: web-build
+          path: ./bin/releases/web-build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
           sudo apt-get install -y git python3 cmake
       - name: Setup emscripten
         run: |
-          git clone https://https://github.com/emscripten-core/emsdk.git
+          git clone https://github.com/emscripten-core/emsdk.git
           cd emsdk
           git pull
           ./emsdk install latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,13 +45,6 @@ jobs:
         run: |
           source ./emsdk/emsdk_env.sh
           make web
-      - name: Copy files to folder
-        run: |
-          mkdir emscripten
-          cp ./index.data ./emsripten
-          cp ./index.html ./emsripten
-          cp ./index.js ./emsripten
-          cp ./index.wasm ./emsripten
       - name: Upload Web build
         uses: actions/upload-artifact@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+# Global variables
+CC         ?= g++
+EMCC       ?= emcc
+CFLAGS     ?= -std=c++14 -O3 -Wall -m64
+LDFLAGS    ?= -lSDL2main -lSDL2 -lSDL2_image -lSDL2_ttf -lSDL2_mixer
+EMCC_FLAGS ?= -O2 -s USE_SDL=2 -s USE_SDL_IMAGE=2 -s \"SDL2_IMAGE_FORMATS=['png']\" -s USE_SDL_TTF=2 -s USE_SDL_MIXER=2
+
+# Linux variables
+INCLUDE_PATH     ?= include
+
+# Windows variables
+WIN_EXTRA_LIBS   ?= -lmingw32
+WIN_EXTRA_FLAGS  ?= -L C:/SDL2-w64/lib
+WIN_INCLUDE_PATH ?= C:/SDL2-w64/include
+
+SRC      := src/*.cpp
+OUT_PATH := bin/release
+OUTPUT   := $(OUT_PATH)/main
+
+all: linux
+
+# Prepare build directories
+# Copy over res files from project
+prep:
+	mkdir -p $(OUT_PATH)
+	cp -a res/* bin
+
+linux: prep
+	$(CC) -c $(SRC) $(CFLAGS) -I $(INCLUDE_PATH)
+	$(CC) *.o -o $(OUTPUT) -s $(LDFLAGS)
+
+win: prep
+	$(CC) -c $(SRC) $(CFLAGS) -I $(INCLUDE_PATH) -I $(WIN_INCLUDE_PATH)
+	$(CC) *.o -o $(OUTPUT) -s $(WIN_EXTRA_FLAGS) $(WIN_EXTRA_LIBS) $(LDFLAGS)
+	start $(OUTPUT)
+
+web:
+	$(EMCC) $(SRC) -I $(INCLUDE_PATH) $(EMCC_FLAGS) \
+		--preload-file res \
+		-o index.html
+
+.PHONY: all linux win web

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ EMCCFLAGS  ?= -O2 -s USE_SDL=2 \
 
 SRC      := $(wildcard src/*.cpp)
 BASEPATH := bin/releases
+RES      := $(wildcard res/*)
 
 # Check the OS and assign variables
 ifeq ($(OS),Windows_NT)
@@ -17,10 +18,10 @@ SDL2PATH        ?= C:/SDL2-w64
 SDL2LIBPATH     := $(SDL2PATH)/lib
 SDL2INCLUDEPATH := $(SDL2PATH)/include
 
-LDFLAGS += -lmingw32 -L $(SDL2LIBPATH)
-CXXFLAGS  += -I $(SDL2INCLUDEPATH)
-OUTPATH := $(BASEPATH)/win
-OUTPUT  := $(OUTPATH)/tgolf.exe
+LDFLAGS  += -lmingw32 -L $(SDL2LIBPATH)
+CXXFLAGS += -I $(SDL2INCLUDEPATH)
+OUTPATH  := $(BASEPATH)/win
+OUTPUT   := $(OUTPATH)/tgolf.exe
 endif
 
 OUTPATH := $(BASEPATH)/linux
@@ -30,11 +31,11 @@ all: build
 
 normal-prep:
 	mkdir -p $(BASEPATH) $(OUTPATH)
-	cp -vr res/* $(OUTPATH)
+	cp -vr $(RES) $(OUTPATH)
 
 web-prep:
 	mkdir -p $(BASEPATH)/web-build
-	cp -vr res/* $(BASEPATH)/web-build
+	cp -vr $(RES) $(BASEPATH)/web-build
 
 build: normal-prep
 	$(CXX) -c $(SRC) $(CXXFLAGS)
@@ -47,4 +48,7 @@ web: web-prep
 	cp -t $(BASEPATH)/web-build index.html index.js \
 		index.data index.wasm
 
-.PHONY: all normal-prep web-prep build web
+clean:
+	rm -rf $(SRC:.c=.o) $(BASEPATH)
+
+.PHONY: all normal-prep web-prep build web clean

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ all: linux
 # Copy over res files from project
 prep:
 	mkdir -p $(OUT_PATH)
-	cp -a res/* bin
+	cp -vr res/* bin
 
 linux: prep
 	$(CC) -c $(SRC) $(CFLAGS) -I $(INCLUDE_PATH)

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 # Global variables
-CC         ?= g++
+G++        ?= g++
 EMCC       ?= emcc
 CFLAGS     ?= -std=c++14 -O3 -Wall -m64
 LDFLAGS    ?= -lSDL2main -lSDL2 -lSDL2_image -lSDL2_ttf -lSDL2_mixer
-EMCC_FLAGS ?= -O2 -s USE_SDL=2 -s USE_SDL_IMAGE=2 -s \"SDL2_IMAGE_FORMATS=['png']\" -s USE_SDL_TTF=2 -s USE_SDL_MIXER=2
+EMCC_FLAGS ?= -O2 -s USE_SDL=2 -s USE_SDL_IMAGE=2 -s 'SDL2_IMAGE_FORMATS=["png"]' -s USE_SDL_TTF=2 -s USE_SDL_MIXER=2
 
 # Linux variables
 INCLUDE_PATH     ?= include
@@ -26,12 +26,12 @@ prep:
 	cp -vr res/* bin
 
 linux: prep
-	$(CC) -c $(SRC) $(CFLAGS) -I $(INCLUDE_PATH)
-	$(CC) *.o -o $(OUTPUT) -s $(LDFLAGS)
+	$(G++) -c $(SRC) $(CFLAGS) -I $(INCLUDE_PATH)
+	$(G++) *.o -o $(OUTPUT) -s $(LDFLAGS)
 
 win: prep
-	$(CC) -c $(SRC) $(CFLAGS) -I $(INCLUDE_PATH) -I $(WIN_INCLUDE_PATH)
-	$(CC) *.o -o $(OUTPUT) -s $(WIN_EXTRA_FLAGS) $(WIN_EXTRA_LIBS) $(LDFLAGS)
+	$(G++) -c $(SRC) $(CFLAGS) -I $(INCLUDE_PATH) -I $(WIN_INCLUDE_PATH)
+	$(G++) *.o -o $(OUTPUT) -s $(WIN_EXTRA_FLAGS) $(WIN_EXTRA_LIBS) $(LDFLAGS)
 	start $(OUTPUT)
 
 web:

--- a/Makefile
+++ b/Makefile
@@ -1,45 +1,50 @@
 # Global variables
-G++        ?= g++
 EMCC       ?= emcc
-CFLAGS     ?= -std=c++14 -O3 -Wall -m64
+CXXFLAGS   ?= -std=c++14 -O3 -Wall -m64 -I include
 LDFLAGS    ?= -lSDL2main -lSDL2 -lSDL2_image -lSDL2_ttf -lSDL2_mixer
-EMCC_FLAGS ?= -O2 -s USE_SDL=2 -s USE_SDL_IMAGE=2 -s 'SDL2_IMAGE_FORMATS=["png"]' -s USE_SDL_TTF=2 -s USE_SDL_MIXER=2
+EMCCFLAGS  ?= -O2 -s USE_SDL=2 \
+	-s USE_SDL_IMAGE=2 \
+	-s 'SDL2_IMAGE_FORMATS=["png"]' \
+	-s USE_SDL_TTF=2 \
+	-s USE_SDL_MIXER=2
 
-SRC      := src/*.cpp
+SRC      := $(wildcard src/*.cpp)
 BASEPATH := bin/releases
 
 # Check the OS and assign variables
 ifeq ($(OS),Windows_NT)
-SDL2PATH          ?= C:/SDL2-w64
-SDL2_LIB_PATH     := $(SDL2PATH)/lib
-SDL2_INCLUDE_PATH := $(SDL2PATH)/include
+SDL2PATH        ?= C:/SDL2-w64
+SDL2LIBPATH     := $(SDL2PATH)/lib
+SDL2INCLUDEPATH := $(SDL2PATH)/include
 
-LDFLAGS    += -lmingw32 -L $(SDL2_LIB_PATH)
-MISC_FLAGS := -I include -I $(SDL2_INCLUDE_PATH)
-OUTPATH    := $(BASEPATH)/win
-OUTPUT     := $(OUTPATH)/tgolf.exe
-else
-MISC_FLAGS  := -I include
-OUTPATH     := $(BASEPATH)/linux
-OUTPUT      := $(OUTPATH)/tgolf
+LDFLAGS += -lmingw32 -L $(SDL2LIBPATH)
+CXXFLAGS  += -I $(SDL2INCLUDEPATH)
+OUTPATH := $(BASEPATH)/win
+OUTPUT  := $(OUTPATH)/tgolf.exe
 endif
+
+OUTPATH := $(BASEPATH)/linux
+OUTPUT  := $(OUTPATH)/tgolf
 
 all: build
 
-prep:
+normal-prep:
 	mkdir -p $(BASEPATH) $(OUTPATH)
 	cp -vr res/* $(OUTPATH)
 
-build: prep
-	$(G++) -c $(SRC) $(CFLAGS) $(MISC_FLAGS)
-	$(G++) *.o -o $(OUTPUT) -s $(LDFLAGS)
-
-web:
+web-prep:
 	mkdir -p $(BASEPATH)/web-build
-	$(EMCC) $(SRC) -I include $(EMCC_FLAGS) \
+	cp -vr res/* $(BASEPATH)/web-build
+
+build: normal-prep
+	$(CXX) -c $(SRC) $(CXXFLAGS)
+	$(CXX) *.o -o $(OUTPUT) -s $(LDFLAGS)
+
+web: web-prep
+	$(EMCC) $(SRC) -I include $(EMCCFLAGS) \
 		--preload-file res \
 		-o index.html
 	cp -t $(BASEPATH)/web-build index.html index.js \
 		index.data index.wasm
 
-.PHONY: all build web
+.PHONY: all normal-prep web-prep build web

--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@ The sections below describe how to compile your own copy of Twini-Golf based on 
 
 After installing [Mingw64](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-win32/seh/x86_64-8.1.0-release-win32-seh-rt_v6-rev0.7z/download), [SDL2](https://www.libsdl.org/download-2.0.php), [SDL_Image](https://www.libsdl.org/projects/SDL_image/), [SDL_TTF](https://www.libsdl.org/projects/SDL_ttf/), and [SDL_Mixer](https://www.libsdl.org/projects/SDL_mixer/), execute the following command in the project's root directory
 
-    make win
+    make
 
-The compiled `.exe` is located in `./bin`. For it to run, you must copy all ``.dll`` files from your SDL installation to its location.
+The compiled `.exe` is located in `./bin/releases/win`. For it to run, you must copy all `.dll` files from your SDL installation to its location.
 
 ### Linux
 
 After installing the dev packages of SDL2 for your distribution, execute the following command in the project's root directory
 
-    make linux
+    make
 
-The compiled binary ``main`` is located in ``./bin``. Resource files are automatically copied over.
+The compiled binary, `tgolf`, is located in `./bin/releases/linux`. Resource files are automatically copied over.
 
 ### Web (Untested)
 
@@ -37,7 +37,7 @@ Install [emscripten](https://emscripten.org/docs/getting_started/downloads.html)
 
     make web
 
-The compiled ``.js``, ``.wasm``, ``.data``, and ``.html`` files are located in the project's root.
+All compiled files (`.js`, `.wasm`, `.data`, and `.html`) are located in `./bin/releases/web-build`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,34 +1,44 @@
 # Twini-Golf
 
 Twini-Golf is a game created in 48 hours for the [2021 GMTK Game Jam](https://itch.io/jam/gmtk-2021) using C++ and [SDL2](https://www.libsdl.org/). It can be played on [itch.io](https://polymars.itch.io/twini-golf).
-## Screenshots
-![](https://img.itch.zone/aW1hZ2UvMTA4NTg3OS82MjU2MjM4LmdpZg==/347x500/e7XF4j.gif) 
 
-![](https://img.itch.zone/aW1hZ2UvMTA4NTg3OS82MjU2MzQzLmdpZg==/347x500/EwUBBI.gif)
+## Screenshots
+
+![gameimg](https://img.itch.zone/aW1hZ2UvMTA4NTg3OS82MjU2MjM4LmdpZg==/347x500/e7XF4j.gif)
+![gamegif](https://img.itch.zone/aW1hZ2UvMTA4NTg3OS82MjU2MzQzLmdpZg==/347x500/EwUBBI.gif)
 
 ## Background
+
 Twini-Golf is an experimental mini golf game where you play on multiple golf courses at once, simultaneously controlling each ball. More information on how to play is available on the game's [itch.io page](https://polymars.itch.io/twini-golf).
 
 ## Compiling
+
+The sections below describe how to compile your own copy of Twini-Golf based on your platform.
+
 ### Windows
-After installing [Mingw64](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-win32/seh/x86_64-8.1.0-release-win32-seh-rt_v6-rev0.7z/download), [SDL2](https://www.libsdl.org/download-2.0.php), [SDL_Image](https://www.libsdl.org/projects/SDL_image/), [SDL_TTF](https://www.libsdl.org/projects/SDL_ttf/), and [SDL_Mixer](https://www.libsdl.org/projects/SDL_mixer/), execute the following command in the project's root directory:
-```
-g++ -c src/*.cpp -std=c++14 -O3 -Wall -m64 -I include -I C:/SDL2-w64/include && g++ *.o -o bin/release/main -s -L C:/SDL2-w64/lib -lmingw32 -lSDL2main -lSDL2 -lSDL2_image -lSDL2_ttf -lSDL2_mixer && start bin/release/main
-```
-The compiled ``.exe`` is located in ``./bin``. For it to run, you must copy the ``./res`` folder as well as all ``.dll`` files from your SDL installation to its directory.
+
+After installing [Mingw64](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-win32/seh/x86_64-8.1.0-release-win32-seh-rt_v6-rev0.7z/download), [SDL2](https://www.libsdl.org/download-2.0.php), [SDL_Image](https://www.libsdl.org/projects/SDL_image/), [SDL_TTF](https://www.libsdl.org/projects/SDL_ttf/), and [SDL_Mixer](https://www.libsdl.org/projects/SDL_mixer/), execute the following command in the project's root directory
+
+    make win
+
+The compiled `.exe` is located in `./bin`. For it to run, you must copy all ``.dll`` files from your SDL installation to its location.
+
 ### Linux
-After installing the dev packages of SDL2 for your distribution, execute the following command in the project's root directory:
-```
-g++ -c src/*.cpp -std=c++14 -O3 -Wall -m64 -I include && mkdir -p bin/release && g++ *.o -o bin/release/main -s -lSDL2main -lSDL2 -lSDL2_image -lSDL2_ttf -lSDL2_mixer
-```
-The compiled binary ``main`` is located in ``./bin``. For it to run, you must copy the ``./res`` folder to its directory.
+
+After installing the dev packages of SDL2 for your distribution, execute the following command in the project's root directory
+
+    make linux
+
+The compiled binary ``main`` is located in ``./bin``. Resource files are automatically copied over.
+
 ### Web (Untested)
-Install [emscripten](https://emscripten.org/docs/getting_started/downloads.html) and execute the following command in the project's root directory:
-```
-emcc src/main.cpp src/entity.cpp src/renderwindow.cpp src/ball.cpp src/tile.cpp src/hole.cpp -I include -O2 -s USE_SDL=2 -s USE_SDL_IMAGE=2 -s \"SDL2_IMAGE_FORMATS=['png']\" -s USE_SDL_TTF=2 -s USE_SDL_MIXER=2 --preload-file res -o index.html
-```
+
+Install [emscripten](https://emscripten.org/docs/getting_started/downloads.html) and execute the following command in the project's root directory
+
+    make web
+
 The compiled ``.js``, ``.wasm``, ``.data``, and ``.html`` files are located in the project's root.
 
-
 ## Contributing
+
 Pull requests are welcome! For major refactors, please open an issue first to discuss what you would like to improve. Feel free to create a fork of this repository or use the code for any other noncommercial purposes.


### PR DESCRIPTION
This PR makes building the project much easier and flexible by using a Makefile. This way, a two-liner can be used in order to do all the work (rather than a long command with arguments).

The workflow was also changed in order to use the Makefile, and the new commands were reflected on the README. Specific changes have been documented in the commit message.