### PR TITLE
Multiple fixes...

### DIFF
--- a/src/RenderWindow.h
+++ b/src/RenderWindow.h
@@ -14,8 +14,8 @@ public:
 	void clear();
 	void render(Entity& p_entity);
 	void render(int x, int y, SDL_Texture* p_tex);
-	void render(float p_x, float p_y, const char* p_text, TTF_Font* font, SDL_Color textColor);
-	void renderCenter(float p_x, float p_y, const char* p_text, TTF_Font* font, SDL_Color textColor);
+	void render(float p_x, float p_y, std::string p_string, TTF_Font* font, SDL_Color textColor);
+	void renderCenter(float p_x, float p_y, std::string p_string, TTF_Font* font, SDL_Color textColor);
 	void display();
 private:
 	SDL_Window* window;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,9 +16,9 @@ bool init()
 	if (SDL_Init(SDL_INIT_VIDEO) > 0)
 		std::cout << "HEY.. SDL_Init HAS FAILED. SDL_ERROR: " << SDL_GetError() << std::endl;
 	if (!(IMG_Init(IMG_INIT_PNG)))
-		std::cout << "IMG_init has failed. Error: " << SDL_GetError() << std::endl;
-	if (!(TTF_Init()))
-		std::cout << "TTF_init has failed. Error: " << SDL_GetError() << std::endl;
+		std::cout << "IMG_init has failed. Error: " << IMG_GetError() << std::endl;
+	if ((TTF_Init()))
+		std::cout << "TTF_init has failed. Error: " << TTF_GetError() << std::endl;
 	Mix_OpenAudio(44100, MIX_DEFAULT_FORMAT, 2, 2048);
 	return true;
 }
@@ -44,7 +44,7 @@ SDL_Texture* powerMeterTexture_overlay = window.loadTexture("res/gfx/powermeter_
 SDL_Texture* logoTexture = window.loadTexture("res/gfx/logo.png");
 SDL_Texture* click2start = window.loadTexture("res/gfx/click2start.png");
 SDL_Texture* endscreenOverlayTexture = window.loadTexture("res/gfx/end.png");
-SDL_Texture* splashBgTexture = window.loadTexture("res/gfx/splashbg.png");
+SDL_Texture* splashBgTexture = window.loadTexture("res/gfx/splashBg.png");
 
 Mix_Chunk* chargeSfx = Mix_LoadWAV("res/sfx/charge.mp3");
 Mix_Chunk* swingSfx = Mix_LoadWAV("res/sfx/swing.mp3");
@@ -56,6 +56,7 @@ SDL_Color black = { 0, 0, 0 };
 TTF_Font* font32 = TTF_OpenFont("res/font/font.ttf", 32);
 TTF_Font* font48 = TTF_OpenFont("res/font/font.ttf", 48);
 TTF_Font* font24 = TTF_OpenFont("res/font/font.ttf", 24);
+
 
 Ball balls[2] = {Ball(Vector2f(0, 0), ballTexture, pointTexture, powerMeterTexture_FG, powerMeterTexture_BG, 0), Ball(Vector2f(0, 0), ballTexture, pointTexture, powerMeterTexture_FG, powerMeterTexture_BG, 1)};
 std::vector<Hole> holes = {Hole(Vector2f(0, 0), holeTexture), Hole(Vector2f(0, 0), holeTexture)};
@@ -195,7 +196,7 @@ void loadLevel(int level)
 	}
 }
 
-const char* getStrokeText()
+std::string getStrokeText()
 {
 	int biggestStroke = 0;
 	if (balls[1].getStrokes() > balls[0].getStrokes())
@@ -208,10 +209,10 @@ const char* getStrokeText()
 	}
 	std::string s = std::to_string(biggestStroke);
 	s = "STROKES: " + s;
-	return s.c_str();
+	return s;
 }
 
-const char* getLevelText(int side)
+std::string getLevelText(int side)
 {
 	int tempLevel = (level + 1)*2 - 1;
 	if (side == 1)
@@ -220,7 +221,7 @@ const char* getLevelText(int side)
 	}
 	std::string s = std::to_string(tempLevel);
 	s = "HOLE: " + s;
-	return s.c_str();
+	return s;
 }
 
 void update()
@@ -405,6 +406,7 @@ void game()
 }
 int main(int argc, char* args[])
 {
+
 	loadLevel(level);
 	while (gameRunning)
 	{
@@ -414,6 +416,7 @@ int main(int argc, char* args[])
 	window.cleanUp();
 	TTF_CloseFont(font32);
 	TTF_CloseFont(font24);
+	TTF_CloseFont(font48);
 	SDL_Quit();
 	TTF_Quit();
 	return 0;

--- a/src/renderwindow.cpp
+++ b/src/renderwindow.cpp
@@ -5,6 +5,7 @@
 
 #include "RenderWindow.h"
 #include "Entity.h"
+#include "config.hpp"
 
 RenderWindow::RenderWindow(const char* p_title, int p_w, int p_h)
 	:window(NULL), renderer(NULL)
@@ -76,9 +77,10 @@ void RenderWindow::render(int x, int y, SDL_Texture* p_tex)
 	SDL_RenderCopy(renderer, p_tex, &src, &dst);
 }
 
-void RenderWindow::render(float p_x, float p_y, const char* p_text, TTF_Font* font, SDL_Color textColor)
+void RenderWindow::render(float p_x, float p_y, std::string p_text, TTF_Font* font, SDL_Color textColor)
 {
-		SDL_Surface* surfaceMessage = TTF_RenderText_Blended( font, p_text, textColor);
+
+		SDL_Surface* surfaceMessage = TTF_RenderText_Blended( font, p_text.c_str(), textColor);
 		SDL_Texture* message = SDL_CreateTextureFromSurface(renderer, surfaceMessage);
 
 		SDL_Rect src;
@@ -95,29 +97,29 @@ void RenderWindow::render(float p_x, float p_y, const char* p_text, TTF_Font* fo
 
 		SDL_RenderCopy(renderer, message, &src, &dst);
 		SDL_FreeSurface(surfaceMessage);
-	 	SDL_DestroyTexture(message);
+		SDL_DestroyTexture(message);
 }
 
-void RenderWindow::renderCenter(float p_x, float p_y, const char* p_text, TTF_Font* font, SDL_Color textColor)
+void RenderWindow::renderCenter(float p_x, float p_y, std::string p_text, TTF_Font* font, SDL_Color textColor)
 {
-		SDL_Surface* surfaceMessage = TTF_RenderText_Blended( font, p_text, textColor);
-		SDL_Texture* message = SDL_CreateTextureFromSurface(renderer, surfaceMessage);
+	SDL_Surface* surfaceMessage = TTF_RenderText_Blended( font, p_text.c_str(), textColor);
+	SDL_Texture* message = SDL_CreateTextureFromSurface(renderer, surfaceMessage);
 
-		SDL_Rect src;
-		src.x = 0;
-		src.y = 0;
-		src.w = surfaceMessage->w;
-		src.h = surfaceMessage->h; 
+	SDL_Rect src;
+	src.x = 0;
+	src.y = 0;
+	src.w = surfaceMessage->w;
+	src.h = surfaceMessage->h; 
 
-		SDL_Rect dst;
-		dst.x = 640/2 - src.w/2 + p_x;
-		dst.y = 480/2 - src.h/2 + p_y;
-		dst.w = src.w;
-		dst.h = src.h;
+	SDL_Rect dst;
+	dst.x = 640/2 - src.w/2 + p_x;
+	dst.y = 480/2 - src.h/2 + p_y;
+	dst.w = src.w;
+	dst.h = src.h;
 
-		SDL_RenderCopy(renderer, message, &src, &dst);
-		SDL_FreeSurface(surfaceMessage);
-		SDL_DestroyTexture(message);
+	SDL_RenderCopy(renderer, message, &src, &dst);
+	SDL_FreeSurface(surfaceMessage);
+	SDL_DestroyTexture(message);
 }
 
 void RenderWindow::display()

--- a/src/renderwindow.cpp
+++ b/src/renderwindow.cpp
@@ -5,7 +5,6 @@
 
 #include "RenderWindow.h"
 #include "Entity.h"
-#include "config.hpp"
 
 RenderWindow::RenderWindow(const char* p_title, int p_w, int p_h)
 	:window(NULL), renderer(NULL)


### PR DESCRIPTION
- Fixed init() printing out SDL Errors instead of TTF/IMG Errors.
- Fixed init() printing out "TTF_init has failed. Error: " everytime TTF_Init initalized correctly.
- Fixed crash on startup by changing char* to std::string on levelText and strokeText getter functions.
- Fixed splashBg not being loaded.
These are all the bugs I noticed while trying to compile on Linux with g++.